### PR TITLE
Use reletive urls instead of hardcoded mixed http/https

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,15 @@
 
 <html ng-app="app">
     <head>
-        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
-        <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
+        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
+        <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
         <link href="assets/styles.css" rel="stylesheet">
         
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.14/angular.js"></script>
         <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
         <script src="bower_components/angular-ui-router/release/angular-ui-router.min.js"></script>
         
-        <script src="http://code.highcharts.com/adapters/standalone-framework.js"></script>
+        <script src="//code.highcharts.com/adapters/standalone-framework.js"></script>
         <script src="bower_components/highcharts-release/highcharts.js"></script>
         
         <!-- just want to know who's visiting, from where -->
@@ -27,7 +27,7 @@
         <script type="text/x-mathjax-config">
           MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
         </script>
-        <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         
         <script src="app.js"></script>
         <script src="app/providers.js"></script>


### PR DESCRIPTION
I got an error when loading the page in chrome (chart was not loaded). The cause was the mixed usage of HTTP and HTTPS. 

Chrome error:

> Mixed Content: The page at 'https://bitcoinstability.github.io/bitcoinstability/#/stability' was loaded over HTTPS, but requested an insecure script 'http://code.highcharts.com/adapters/standalone-framework.js'. This request has been blocked; the content must be served over HTTPS.

I fixed it by using relative urls for the css and js files.
